### PR TITLE
#4: Failed to run report generator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,14 +69,14 @@
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
     </repositories>
 
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
 

--- a/src/main/java/com/xceptance/xlt/tools/jenkins/XltTask.java
+++ b/src/main/java/com/xceptance/xlt/tools/jenkins/XltTask.java
@@ -579,14 +579,7 @@ public class XltTask
         // delete any temporary directory with local XLT
         try
         {
-            FilePath tempXltBuildFolder = getTemporaryXltBuildFolder(run, launcher);
-            tempXltBuildFolder.deleteRecursive();
-
-//            FilePath tempFolder = getTemporaryXltBaseFolder(run, launcher);
-//            if (tempFolder.exists() && (tempFolder.list() == null || tempFolder.list().isEmpty()))
-//            {
-//                tempFolder.delete();
-//            }
+            getTemporaryXltBuildFolder(run, launcher).deleteRecursive();
         }
         catch (Exception e)
         {
@@ -857,17 +850,6 @@ public class XltTask
             return new FilePath(getTestSuiteConfigFolder(workspace), testPropertiesFile);
         }
         return null;
-    }
-
-    private void initialCleanUp(final Run<?, ?> run, final Launcher launcher, final TaskListener listener)
-        throws IOException, InterruptedException, BuildNodeGoneException
-    {
-        listener.getLogger()
-                .println("-----------------------------------------------------------------\nCleaning up project directory ...\n");
-
-        getTemporaryXltProjectFolder(run, launcher).deleteRecursive();
-
-        listener.getLogger().println("\nFinished");
     }
 
     private void copyXlt(final Run<?, ?> run, final Launcher launcher, final TaskListener listener) throws Exception
@@ -1497,16 +1479,6 @@ public class XltTask
         }
 
         init();
-
-        try
-        {
-            initialCleanUp(run, launcher, listener);
-        }
-        catch (Exception e)
-        {
-            listener.getLogger().println("Cleanup failed: " + e.getMessage());
-            LOGGER.error("Cleanup failed: ", e);
-        }
 
         boolean reportsSaved = false, resultsSaved = false;
         try

--- a/src/main/java/com/xceptance/xlt/tools/jenkins/XltTask.java
+++ b/src/main/java/com/xceptance/xlt/tools/jenkins/XltTask.java
@@ -579,14 +579,14 @@ public class XltTask
         // delete any temporary directory with local XLT
         try
         {
-            FilePath tempProjectFolder = getTemporaryXltProjectFolder(run, launcher);
-            tempProjectFolder.deleteRecursive();
+            FilePath tempXltBuildFolder = getTemporaryXltBuildFolder(run, launcher);
+            tempXltBuildFolder.deleteRecursive();
 
-            FilePath tempFolder = getTemporaryXltBaseFolder(run, launcher);
-            if (tempFolder.exists() && (tempFolder.list() == null || tempFolder.list().isEmpty()))
-            {
-                tempFolder.delete();
-            }
+//            FilePath tempFolder = getTemporaryXltBaseFolder(run, launcher);
+//            if (tempFolder.exists() && (tempFolder.list() == null || tempFolder.list().isEmpty()))
+//            {
+//                tempFolder.delete();
+//            }
         }
         catch (Exception e)
         {


### PR DESCRIPTION
Don't delete temporary XLT folders that don't belong to the current run as this would harm parallel runs of this job/project.